### PR TITLE
API Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/_build
 patchserver/patch_server.db
+patchserver/reset_api_token

--- a/docs/apis/auth.rst
+++ b/docs/apis/auth.rst
@@ -1,0 +1,45 @@
+API Authentication
+==================
+
+You may optionally generate an API token that will be required for all requests
+made to the following ``/api/v1/title*`` endpoints to prevent unauthenticated
+requests to create, update, or delete software titles.
+
+.. note::
+
+    The ``/jamf/v1`` and ``/api/v1/backup`` endpoints remain open and will not
+    use the API token for authentication.
+
+.. warning::
+
+    THe UI does not yet support API authentication. You will receive a
+    **"Unauthorized: Authentication required"** message if you attempt to use
+    the **New Title +** or **X (delete)** options.
+
+See the :doc:`Patch Server API documentation <./ps_api>` for how to create an
+API token.
+
+Authenticating Requests
+-----------------------
+
+If you have created an API token, you must include it with your requests in the
+``Authorization`` header and the ``Bearer`` type::
+
+    Authorization: Bearer 94631ec5c65e4dd19fb81479abdd2929
+
+Requests without this header will be rejected with a ``401`` status.
+
+Retrieve/Reset the API Token
+----------------------------
+
+In the event you lose your API token, you can use a command line utillity such
+as ``sqlite3`` to retrieve the existing token:
+
+.. code-block:: bash
+
+    $ sqlite3 patch_server.db "SELECT * FROM api_token;"
+
+If you wish to reset the token, write a stub file into the ``patchserver``
+application directory named ``reset_api_token`` and restart the server. The API
+token will be deleted from the database and the stub file cleared. You will then
+be allowed to create a new API token using ``/api/v1/token``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ An open-source implementation of an external patch source for use with Jamf Pro
    :maxdepth: 1
    :caption: API Documentation
 
+   apis/auth
    apis/ps_api
    apis/jamf_pro
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,6 +111,11 @@ definitions for all your software titles.
 Change History
 --------------
 
+0.6.0 (2018-02-14)
+^^^^^^^^^^^^^^^^^^
+
+You can secure the API with token authentication (if you really want to).
+
 0.5.3 (2018-02-13)
 ^^^^^^^^^^^^^^^^^^
 

--- a/patchserver/__init__.py
+++ b/patchserver/__init__.py
@@ -1,4 +1,4 @@
 """Patch Server for Jamf Pro"""
 __title__ = 'PatchServer'
-__version__ = '0.5.3'
+__version__ = '0.6.0'
 __author__ = 'Bryson Tyrrell'

--- a/patchserver/config.py
+++ b/patchserver/config.py
@@ -11,5 +11,6 @@ DATABASE_PATH = os.path.join(
     os.environ.get('DATABASE_DIR', APP_DIR), 'patch_server.db')
 
 SQLALCHEMY_DATABASE_URI = 'sqlite:////{}' .format(DATABASE_PATH)
-
 SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+RESET_API_TOKEN = os.path.exists(os.path.join(APP_DIR, 'reset_api_token'))

--- a/patchserver/exc.py
+++ b/patchserver/exc.py
@@ -2,6 +2,10 @@ class PatchServerException(Exception):
     pass
 
 
+class Unauthorized(PatchServerException):
+    pass
+
+
 class InvalidPatchDefinitionError(PatchServerException):
     pass
 

--- a/patchserver/factory.py
+++ b/patchserver/factory.py
@@ -5,6 +5,7 @@ import os
 from . import config
 from .database import db
 from .routes import api, error_handlers, jamf_pro, web_ui
+from .utilities import reset_api_token
 
 
 def register_blueprints(app):
@@ -26,6 +27,9 @@ def create_app():
     # if not os.path.exists(config.DATABASE_PATH):
     with app.app_context():
         db.create_all()
+
+        if app.config.get('RESET_API_TOKEN'):
+            reset_api_token()
 
     if app.config.get('SQL_LOGGING'):
         sql_logger = logging.getLogger('sqlalchemy.engine')

--- a/patchserver/factory.py
+++ b/patchserver/factory.py
@@ -23,9 +23,9 @@ def create_app():
     app.config.from_object(config)
     db.init_app(app)
 
-    if not os.path.exists(config.DATABASE_PATH):
-        with app.app_context():
-            db.create_all()
+    # if not os.path.exists(config.DATABASE_PATH):
+    with app.app_context():
+        db.create_all()
 
     if app.config.get('SQL_LOGGING'):
         sql_logger = logging.getLogger('sqlalchemy.engine')

--- a/patchserver/models.py
+++ b/patchserver/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import hashlib
 from operator import itemgetter
+import uuid
 
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
@@ -23,6 +24,21 @@ def datetime_to_iso(date):
     :param datetime date: Datetime object
     """
     return date.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def generate_token():
+    """Created a 32 character token from a UUID"""
+    return uuid.uuid4().hex
+
+
+class ApiToken(db.Model):
+    __tablename__ = 'api_token'
+
+    id = db.Column(db.Integer, primary_key=True)
+
+    token = db.Column(db.String(32), default=generate_token)
+    created_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 
 def sorted_criteria(criteria_list):

--- a/patchserver/routes/api.py
+++ b/patchserver/routes/api.py
@@ -20,9 +20,22 @@ from .api_operations import (
 from .validator import validate_json
 from ..database import db
 from ..exc import InvalidPatchDefinitionError
-from ..models import SoftwareTitle
+from ..models import ApiToken, SoftwareTitle
 
 blueprint = blueprints.Blueprint('api', __name__, url_prefix='/api/v1')
+
+
+@blueprint.route('/token', methods=['POST'])
+def token_create():
+    if ApiToken.query.first():
+        return jsonify(
+            {'Denied': 'A token already exists for this server'}), 403
+
+    new_token = ApiToken()
+    db.session.add(new_token)
+    db.session.commit()
+
+    return jsonify({'token_created': new_token.token}), 201
 
 
 @blueprint.route('/title', methods=['POST'])

--- a/patchserver/routes/auth.py
+++ b/patchserver/routes/auth.py
@@ -1,0 +1,30 @@
+import functools
+
+from flask import current_app, request
+
+from ..exc import Unauthorized
+from ..models import ApiToken
+
+
+def api_auth(func):
+    """A decorator for routes that requires token authentication on a request if
+    the API token exists in the database.
+    """
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        api_token = ApiToken.query.first()
+        if api_token:
+            auth_header = request.headers.get('Authorization')
+            if not auth_header:
+                raise Unauthorized('Authentication required')
+
+            schema, auth_token = auth_header.split()
+            current_app.logger.debug(schema)
+            current_app.logger.debug(auth_token)
+
+            if schema != 'Bearer' or api_token.token != auth_token:
+                raise Unauthorized('Invalid token provided')
+
+            current_app.logger.debug('Auth successful')
+        return func(*args, **kwargs)
+    return wrapped

--- a/patchserver/routes/error_handlers.py
+++ b/patchserver/routes/error_handlers.py
@@ -1,9 +1,29 @@
 from flask import blueprints, current_app, flash, jsonify, redirect, request, url_for
 from sqlalchemy.exc import IntegrityError
 
-from ..exc import InvalidPatchDefinitionError, SoftwareTitleNotFound
+from ..exc import (
+    InvalidPatchDefinitionError,
+    SoftwareTitleNotFound,
+    Unauthorized
+)
 
 blueprint = blueprints.Blueprint('error_handlers', __name__)
+
+
+@blueprint.app_errorhandler(Unauthorized)
+def unauthorized(err):
+    current_app.logger.error(err.message)
+
+    if request.args.get('redirect'):
+        flash(
+            {
+                'title': 'Unauthorized',
+                'message': err.message
+            },
+            'warning')
+        return redirect(url_for('web_ui.index'))
+    else:
+        return jsonify({'unauthorized': err.message}), 401
 
 
 @blueprint.app_errorhandler(InvalidPatchDefinitionError)

--- a/patchserver/utilities/__init__.py
+++ b/patchserver/utilities/__init__.py
@@ -1,0 +1,26 @@
+import os
+
+from flask import current_app
+
+from ..database import db
+from ..models import ApiToken
+
+
+def reset_api_token():
+    """Deletes the API token in the Patch Server database.
+
+    This function is invoked on startup if the ``reset_api_token`` file has been
+    written to the application directory.
+
+    The file is removed when this function is invoked.
+    """
+    token = ApiToken.query.first()
+    if token:
+        current_app.logger.info("Resetting API Token")
+        db.session.delete(token)
+        db.session.commit()
+
+    current_app.config.pop('RESET_API_TOKEN')
+    current_app.logger.info("Removing 'reset_api_token' stub")
+    os.remove(os.path.join(
+        current_app.config['APP_DIR'], 'reset_api_token'))


### PR DESCRIPTION
Optional API authentication has been added for the **/api/v1/title*** endpoints.

The _Patch Server API_ section of the documentation details how to create your API token.
A new _API Authentication_ section details how to make a authenticated requests after you have created a token, and how to retrieve or reset your API token if it becomes lost.

**>>The UI has not yet been updated to support this feature.<<**