### PR TITLE
v0.8.2

### DIFF
--- a/docs/change_history.rst
+++ b/docs/change_history.rst
@@ -1,6 +1,18 @@
 Change History
 --------------
 
+0.8.2 (2018-06-05)
+^^^^^^^^^^^^^^^^^^
+
+Fixed an issue where a mismatched or non-existing software title ID passed to
+``/jamf/v1/software/<Title>,<Title>`` would result in a 404 error response.
+
+The expected behavior is the invalid title ID to be omitted from the results
+(this is the behavior of both the official Jamf patch feed and CommunityPatch).
+
+Added documentation to describe resources for troubleshooting issues between
+Jamf Pro and a Patch Server.
+
 0.8.1 (2018-05-21)
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ An open-source implementation of an external patch source for use with Jamf Pro
    :caption: Managing Your Patch Server
 
    managing/patch_starter
+   managing/troubleshooting
 
 .. toctree::
    :maxdepth: 1

--- a/docs/managing/patch_starter.rst
+++ b/docs/managing/patch_starter.rst
@@ -31,5 +31,5 @@ for an application and then add it to an existing title on the patch server:
 
     curl http://localhost:5000/api/v1/title/GitHubDesktop/version \
         -X POST \
-        -d "{$(python patchstarter.py /Applications/GitHub\ Desktop.app -p "GitHub" --patch-only)" \
+        -d "$(python patchstarter.py /Applications/GitHub\ Desktop.app -p "GitHub" --patch-only)" \
         -H 'Content-Type: application/json'

--- a/docs/managing/patch_starter.rst
+++ b/docs/managing/patch_starter.rst
@@ -31,5 +31,5 @@ for an application and then add it to an existing title on the patch server:
 
     curl http://localhost:5000/api/v1/title/GitHubDesktop/version \
         -X POST \
-        -d "{\"items\": [$(python patchstarter.py /Applications/GitHub\ Desktop.app -p "GitHub" --patch-only)]}" \
+        -d "{$(python patchstarter.py /Applications/GitHub\ Desktop.app -p "GitHub" --patch-only)" \
         -H 'Content-Type: application/json'

--- a/docs/managing/troubleshooting.rst
+++ b/docs/managing/troubleshooting.rst
@@ -1,0 +1,24 @@
+Troubleshooting
+---------------
+
+If you encounter issues between Jamf Pro and your Patch Server you can
+investigate using the resources detailed here.
+
+Jamf Pro's Connection Test
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Jamf Pro has a test option to verify it can contact the Patch Server and read
+software titles. In Jamf Pro, go to **Settings > Computer Management > Patch**
+**Management > <Your Patch Server>** in the management console.
+
+Click the **Test** button at the bottom of the page.
+
+.. image:: ../_static/jamf_setup_03.png
+   :align: center
+
+Jamf Pro Logs
+^^^^^^^^^^^^^
+
+If you enable ``DEBUG`` mode for Jamf Pro logging, you can search for entries
+with ``SoftwareTitleMonitor``. The debug statements will show when the sync
+occurs, what titles are being requested, and the error encountered.

--- a/patchserver/__init__.py
+++ b/patchserver/__init__.py
@@ -1,4 +1,4 @@
 """Patch Server for Jamf Pro"""
 __title__ = 'PatchServer'
-__version__ = '0.8.1'
+__version__ = '0.8.2'
 __author__ = 'Bryson Tyrrell'

--- a/patchserver/routes/jamf_pro.py
+++ b/patchserver/routes/jamf_pro.py
@@ -136,14 +136,7 @@ def software_titles_select(name_ids):
     title_list = SoftwareTitle.query.filter(
         sqlalchemy.or_(SoftwareTitle.id_name.in_(name_id_list))).all()
 
-    not_found = [name for name in name_id_list
-                 if name not in
-                 [title.id_name for title in title_list]]
-    if not_found:
-        raise SoftwareTitleNotFound(not_found)
-    else:
-        return jsonify(
-            [title.serialize_short for title in title_list]), 200
+    return jsonify([title.serialize_short for title in title_list]), 200
 
 
 @blueprint.route('/patch/<name_id>')


### PR DESCRIPTION
Fixed an issue where a mismatched or non-existing software title ID passed to
``/jamf/v1/software/<Title>,<Title>`` would result in a 404 error response.

The expected behavior is the invalid title ID to be omitted from the results
(this is the behavior of both the official Jamf patch feed and CommunityPatch).

Added documentation to describe resources for troubleshooting issues between
Jamf Pro and a Patch Server.